### PR TITLE
Increase array size from 1024 to 4096

### DIFF
--- a/src/pdns-logger-syslog.c
+++ b/src/pdns-logger-syslog.c
@@ -136,8 +136,8 @@ static pdns_status_t syslog_log(void *rawpb) {
     PBDNSMessage__DNSQuestion *q;
     PBDNSMessage__DNSResponse *r;
     int sz, pc;
-    char str[1024] = "";
-    char tmp[1024] = "";
+    char str[4096] = "";
+    char tmp[4096] = "";
 
     if (disabled) {
         return PDNS_OK;


### PR DESCRIPTION
to accept response with a lot …of cname like amazon.
Before I had: 

```
Segmentation fault (core dumped)
##########################################

gdb /usr/sbin/pdns-logger /Log/core-pdns-logger-sig11-user0-group0-pid10159-time1557223949


(gdb) bt full
#0  0x00007f8860467884 in __strncat_sse2_unaligned () from /lib64/libc.so.6
No symbol table info available.
#1  0x0000000000403a22 in syslog_log (rawpb=0x7f88580008c0) at /opt/pdns-logger/src/pdns-logger-syslog.c:233
       t = 8
       rr = 0x7f8858000b00
       msg = 0x7f88580008c0
       q = 0x7f8858001190
       r = 0x7f88580011d0
       sz = -55
       pc = 81
       str = "QID: 25560 from: 10.13.63.30 qtype: A qclass: IN qname: loca.sc-jpl.com. rcode: NOERROR rrcount: 9 rname-1: loca.sc-jpl.com. rtype-1: CNAME rclass-1: IN rttl-1: 10 rdata-1: a8bed90c7b08811e88de00a555ee"...
       tmp = "rname-8: a8bed90c7b08811e88de00a555ee542a-365725862.us-east-1.elb.amazonaws.com. rname-8: a8bed90c7b08811e88de00a555ee542a-365725862.us-east-1.elb.amazonaws.com. rname-8: a8bed90c7b08811e88de00a555ee5"...
       __PRETTY_FUNCTION__ = "syslog_log"
#2  0x6237633039646562 in ?? ()
No symbol table info available.
```