### PR TITLE
Use the configured bind-ip

### DIFF
--- a/src/pdns-logger-protobuf.c
+++ b/src/pdns-logger-protobuf.c
@@ -217,7 +217,7 @@ static pdns_status_t socket_start(globals_t * conf) {
     }
 
     sa.sin_family = AF_INET;
-    sa.sin_addr.s_addr = INADDR_ANY;
+    sa.sin_addr.s_addr = inet_addr(conf->bind_ip);
     sa.sin_port = htons(conf->bind_port);
 
     flags = 1;


### PR DESCRIPTION
This patch makes the process use the "bind-ip" parameter
in pdns-logger.ini (default: 127.0.0.1).

It previously always bound to INADDR_ANY (i.e. 0.0.0.0),
making it accessible from the outside world.

Signed-off-by: Jan Hilberath <jan.hilberath@open-xchange.com>